### PR TITLE
Fix autofix test string literal

### DIFF
--- a/tests/autofix_test.py
+++ b/tests/autofix_test.py
@@ -1,2 +1,4 @@
 def test_autofix():
-    print("autofix test  
+    message = "autofix test"
+    print(message)
+    assert message == "autofix test"


### PR DESCRIPTION
## Summary
- fix the unterminated string literal in `tests/autofix_test.py`
- add a stored message and assertion so the test runs meaningfully

## Testing
- python -m pytest tests/autofix_test.py

## Notes
- `pip install -r requirements.txt` failed while building dependencies for catboost (PyYAML build error: AttributeError `cython_sources`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fe1be4600832993a093f61090500d)