### PR TITLE
Fix XGBoost tuning rebase failure on dirty runner worktree

### DIFF
--- a/.github/workflows/xgboost_safeguards.yml
+++ b/.github/workflows/xgboost_safeguards.yml
@@ -68,8 +68,8 @@ jobs:
           {
             echo "## XGBoost leakage safeguards"
             echo ""
-            echo "- Event: `${{ github.event_name }}`"
-            echo "- Ref: `${{ github.ref }}`"
-            echo "- Commit: `${{ github.sha }}`"
-            echo "- Result: `${{ job.status }}`"
+            echo '- Event: `${{ github.event_name }}`'
+            echo '- Ref: `${{ github.ref }}`'
+            echo '- Commit: `${{ github.sha }}`'
+            echo '- Result: `${{ job.status }}`'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/xgboost_tuning.yml
+++ b/.github/workflows/xgboost_tuning.yml
@@ -204,8 +204,12 @@ jobs:
             echo "Nothing to commit"
           else
             git commit -m "🔧 Auto: validated XGBoost tuning results - $(date +'%Y-%m-%d %H:%M:%S')"
+            if ! git diff --quiet; then
+              echo "::notice title=Runtime worktree changes::Temporarily stashing unstaged tracked changes for rebase."
+              git status --short
+            fi
             git fetch origin main
-            git rebase origin/main
+            git rebase --autostash origin/main
             git push origin HEAD:main
           fi
 

--- a/tests/test_xgboost_tuning.py
+++ b/tests/test_xgboost_tuning.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 
@@ -28,3 +30,10 @@ def test_chronological_split_preserves_order():
     assert (len(X_train), len(X_val), len(X_test)) == (64, 16, 20)
     assert (len(y_train), len(y_val), len(y_test)) == (64, 16, 20)
     assert X_train.index.max() < X_val.index.min() < X_test.index.min()
+
+
+def test_tuning_workflow_autostashes_unstaged_changes_before_rebase():
+    workflow = Path(".github/workflows/xgboost_tuning.yml").read_text(encoding="utf-8")
+
+    assert "git rebase --autostash origin/main" in workflow
+    assert "git rebase origin/main" not in workflow


### PR DESCRIPTION
## 原因

Scheduled run `32615827714` completed the leakage tests, ten-ticker tuning, result validation, and artifact upload successfully. It failed only in `Commit and push validated results` after creating the result commit because `git rebase origin/main` refused to run with unstaged tracked changes:

`error: cannot rebase: You have unstaged changes.`

The tuning result itself was valid; the failure is in the persistence step.

During PR verification, the safeguard workflow also exposed a separate deterministic shell bug: Markdown backticks inside double-quoted `echo` commands were executed as shell command substitutions, producing `command not found` errors while the job still reported success.

## 修正

- Preserve unstaged tracked runtime changes during the rebase with Git's `--autostash` option.
- Emit `git status --short` only when such runtime changes exist, so future runs identify the paths instead of hiding the condition.
- Keep the existing allowlist of committed outputs (`tuning_output.log` and `tuning_results/`) unchanged.
- Add a regression test that requires the tuning workflow to use `git rebase --autostash origin/main`.
- Quote safeguard summary lines safely so Markdown backticks are written literally instead of executed by the shell.

No Secrets, model inputs, production data, prices, or external services are changed.

Superseded by PR #31, recreated from the current main after this PR became non-mergeable.